### PR TITLE
Embed period forms on index

### DIFF
--- a/miniprogram/pages/index/index.ts
+++ b/miniprogram/pages/index/index.ts
@@ -1,5 +1,5 @@
 import { MarkItem, PeriodRecord } from '../../../typings';
-import { db } from '../../utils/cloudDB';
+import { db, _ } from '../../utils/cloudDB';
 import { generatePhaseMarks, getCurrentPhase } from '../../utils/period';
 
 Page({
@@ -7,7 +7,14 @@ Page({
     currentPhase: '',
     latestStartDate: '',
     markedList: [] as MarkItem[],
-    groupedHistory: [] as Array<{ year: number; records: PeriodRecord[] }>
+    groupedHistory: [] as Array<{ year: number; records: PeriodRecord[] }>,
+    showStartForm: false,
+    showEndForm: false,
+    startSelectedDate: new Date().toISOString().slice(0, 10),
+    endSelectedDate: new Date().toISOString().slice(0, 10),
+    endMaxDate: new Date().toISOString().slice(0, 10),
+    endRecordId: '',
+    endStartDate: ''
   },
 
   async onLoad() {
@@ -52,15 +59,83 @@ Page({
   },
 
   onStartPeriod() {
-    wx.navigateTo({
-      url: '/pages/start/index'
+    this.setData({
+      showStartForm: true,
+      startSelectedDate: new Date().toISOString().slice(0, 10)
     });
-
   },
 
   onEndPeriod() {
-    wx.navigateTo({
-      url: '/pages/end/index'
+    db.collection('periods')
+      .where({ endDate: _.exists(false) })
+      .orderBy('startDate', 'desc')
+      .limit(1)
+      .get()
+      .then(res => {
+        if (res.data.length) {
+          const record = res.data[0] as PeriodRecord;
+          this.setData({
+            showEndForm: true,
+            endRecordId: String(record._id),
+            endStartDate: record.startDate,
+            endSelectedDate: new Date().toISOString().slice(0, 10)
+          });
+        } else {
+          wx.showToast({ title: '无正在进行的周期', icon: 'none' });
+        }
+      });
+  },
+
+  onStartDateChange(e: WechatMiniprogram.PickerChange) {
+    this.setData({ startSelectedDate: e.detail.value as string });
+  },
+
+  async onConfirmStart() {
+    await db.collection('periods').add({
+      data: {
+        startDate: this.data.startSelectedDate
+      }
     });
+    wx.showToast({ title: '已记录开始', icon: 'success' });
+    this.setData({ showStartForm: false });
+    await this.loadPeriodData();
+  },
+
+  onEndDateChange(e: WechatMiniprogram.PickerChange) {
+    this.setData({ endSelectedDate: e.detail.value as string });
+  },
+
+  async onConfirmEnd() {
+    const selected = new Date(this.data.endSelectedDate);
+    const today = new Date();
+    const start = new Date(this.data.endStartDate);
+
+    selected.setHours(0, 0, 0, 0);
+    today.setHours(0, 0, 0, 0);
+    start.setHours(0, 0, 0, 0);
+
+    if (selected.getTime() > today.getTime()) {
+      wx.showToast({ title: '结束日期不能晚于今天', icon: 'none' });
+      return;
+    }
+
+    if (selected.getTime() < start.getTime()) {
+      wx.showToast({ title: '结束日期不能早于开始日期', icon: 'none' });
+      return;
+    }
+
+    try {
+      await db.collection('periods').doc(this.data.endRecordId).update({
+        data: {
+          endDate: this.data.endSelectedDate
+        }
+      });
+      wx.showToast({ title: '已记录结束', icon: 'success' });
+      this.setData({ showEndForm: false });
+      await this.loadPeriodData();
+    } catch (e) {
+      wx.showToast({ title: '记录失败', icon: 'error' });
+      console.error('记录失败', e);
+    }
   }
 });

--- a/miniprogram/pages/index/index.wxml
+++ b/miniprogram/pages/index/index.wxml
@@ -11,6 +11,20 @@
     <button class="primary-btn" bindtap="onStartPeriod">开始经期</button>
     <button class="secondary-btn" bindtap="onEndPeriod">结束经期</button>
   </view>
+  <view class="start-container" wx:if="{{showStartForm}}">
+    <text class="title">请选择经期开始日期</text>
+    <picker mode="date" value="{{startSelectedDate}}" bindchange="onStartDateChange">
+      <view class="date-picker">开始日期：{{startSelectedDate}}</view>
+    </picker>
+    <button class="confirm-btn" bindtap="onConfirmStart">确认记录</button>
+  </view>
+  <view class="end-container" wx:if="{{showEndForm}}">
+    <text class="title">请选择经期结束日期</text>
+    <picker mode="date" value="{{endSelectedDate}}" bindchange="onEndDateChange" end="{{endMaxDate}}">
+      <view class="date-picker">结束日期：{{endSelectedDate}}</view>
+    </picker>
+    <button class="confirm-btn" bindtap="onConfirmEnd">确认结束</button>
+  </view>
 </view>
 <view class="history-section">
   <text class="section-title">我的周期记录</text>

--- a/miniprogram/pages/index/index.wxss
+++ b/miniprogram/pages/index/index.wxss
@@ -107,3 +107,38 @@
   font-size: 24rpx;
   color: #bbb;
 }
+
+.start-container,
+.end-container {
+  padding: 40rpx;
+}
+
+.title {
+  font-size: 32rpx;
+  color: #444;
+  margin-bottom: 24rpx;
+}
+
+.date-picker {
+  padding: 24rpx;
+  border: 1rpx solid #ddd;
+  border-radius: 12rpx;
+  margin-bottom: 40rpx;
+  background-color: #fff8f6;
+}
+
+.start-container .confirm-btn {
+  background-color: #f99ca2;
+  color: white;
+  font-size: 28rpx;
+  height: 88rpx;
+  border-radius: 44rpx;
+}
+
+.end-container .confirm-btn {
+  background-color: #fbc47b;
+  color: white;
+  font-size: 28rpx;
+  height: 88rpx;
+  border-radius: 44rpx;
+}


### PR DESCRIPTION
## Summary
- keep users on index page when recording period dates
- show start period form inline
- show end period form inline

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f8e79f95c83288eda69230ce8f3fe